### PR TITLE
Add test for open identifier

### DIFF
--- a/spec/StrategyASTSchema.json
+++ b/spec/StrategyASTSchema.json
@@ -83,7 +83,7 @@
         "value": {
           "oneOf": [
             {
-              "enum": ["price", "entry_price", "high", "low", "close", "volume"]
+              "enum": ["price", "entry_price", "high", "low", "close", "volume", "open"]
             },
             { "type": "number" }
           ]

--- a/src/lib/dsl-validator.test.ts
+++ b/src/lib/dsl-validator.test.ts
@@ -40,6 +40,43 @@ describe("AST Validation", () => {
     }
   });
 
+  it("should validate an AST with the 'open' identifier", () => {
+    const openAst: StrategyAST = {
+      entry: {
+        ast: {
+          type: "Func",
+          name: "rsi",
+          args: [14],
+        },
+        timing: "close",
+      },
+      exit: {
+        ast: {
+          type: "Binary",
+          op: ">",
+          left: {
+            type: "Value",
+            kind: "IDENT",
+            value: "open",
+          },
+          right: {
+            type: "Value",
+            kind: "NUMBER",
+            value: 100,
+          },
+        },
+        timing: "current_close",
+      },
+      universe: ["7203.T"],
+    };
+
+    const result = validateAst(openAst);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual(openAst);
+    }
+  });
+
   it("should reject invalid function names", () => {
     const invalidAst = {
       entry: {

--- a/src/lib/dsl-validator.ts
+++ b/src/lib/dsl-validator.ts
@@ -6,7 +6,7 @@ const ValueNodeSchema = z.object({
   type: z.literal("Value"),
   kind: z.enum(["IDENT", "NUMBER"]),
   value: z.union([
-    z.enum(["price", "entry_price", "high", "low", "close", "volume"]),
+    z.enum(["price", "entry_price", "high", "low", "close", "volume", "open"]),
     z.number(),
   ]),
 });

--- a/src/lib/dslCompiler.ts
+++ b/src/lib/dslCompiler.ts
@@ -15,6 +15,7 @@ const ALLOWED_COLUMNS = [
   "high",
   "low",
   "close",
+  "open",
   "volume",
 ] as const;
 

--- a/src/types/dslSchema.ts
+++ b/src/types/dslSchema.ts
@@ -9,6 +9,7 @@ const identifierValueSchema = z.enum([
   "high",
   "low",
   "close",
+  "open",
   "volume",
 ]);
 const functionNameSchema = z.enum(["ma", "rsi", "atr"]);


### PR DESCRIPTION
## Summary
- support `open` identifier in validation and compiler
- update JSON schema
- test validation accepts `open`

## Testing
- `npx vitest run src/lib/dsl-validator.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_684fbcb94e1483329bd87b9c661d0c15