### PR TITLE
Add support for open column in DSL

### DIFF
--- a/spec/StrategyASTSchema.json
+++ b/spec/StrategyASTSchema.json
@@ -83,7 +83,15 @@
         "value": {
           "oneOf": [
             {
-              "enum": ["price", "entry_price", "high", "low", "close", "volume"]
+              "enum": [
+                "price",
+                "entry_price",
+                "high",
+                "low",
+                "close",
+                "volume",
+                "open"
+              ]
             },
             { "type": "number" }
           ]

--- a/src/lib/dsl-validator.test.ts
+++ b/src/lib/dsl-validator.test.ts
@@ -40,6 +40,31 @@ describe("AST Validation", () => {
     }
   });
 
+  it("should accept ASTs referencing the open column", () => {
+    const astWithOpen: StrategyAST = {
+      entry: {
+        ast: {
+          type: "Value",
+          kind: "IDENT",
+          value: "open",
+        },
+        timing: "close",
+      },
+      exit: {
+        ast: {
+          type: "Value",
+          kind: "NUMBER",
+          value: 100,
+        },
+        timing: "current_close",
+      },
+      universe: ["7203.T"],
+    };
+
+    const result = validateAst(astWithOpen);
+    expect(result.success).toBe(true);
+  });
+
   it("should reject invalid function names", () => {
     const invalidAst = {
       entry: {

--- a/src/lib/dsl-validator.ts
+++ b/src/lib/dsl-validator.ts
@@ -6,7 +6,15 @@ const ValueNodeSchema = z.object({
   type: z.literal("Value"),
   kind: z.enum(["IDENT", "NUMBER"]),
   value: z.union([
-    z.enum(["price", "entry_price", "high", "low", "close", "volume"]),
+    z.enum([
+      "price",
+      "entry_price",
+      "high",
+      "low",
+      "close",
+      "volume",
+      "open",
+    ]),
     z.number(),
   ]),
 });

--- a/src/lib/dslCompiler.test.ts
+++ b/src/lib/dslCompiler.test.ts
@@ -39,6 +39,7 @@ const valueNodeIdentArb: fc.Arbitrary<ValueNode> = fc.record({
     "high",
     "low",
     "close",
+    "open",
     "volume" as const
   ),
 });
@@ -272,7 +273,7 @@ describe("SQL Injection Prevention", () => {
     const ast: ValueNode = {
       type: "Value",
       kind: "IDENT",
-      value: "price" as const, // 正しい型を使用
+      value: "open" as const,
     };
     const strategyAst: StrategyAST = {
       entry: { ast, timing: "close" },
@@ -280,7 +281,7 @@ describe("SQL Injection Prevention", () => {
       universe: ["7203.T"],
     };
     const sql = compileDslToSql(strategyAst, "valid_column_test");
-    expect(sql).toContain("price");
+    expect(sql).toContain("open");
   });
 });
 

--- a/src/lib/dslCompiler.ts
+++ b/src/lib/dslCompiler.ts
@@ -15,6 +15,7 @@ const ALLOWED_COLUMNS = [
   "high",
   "low",
   "close",
+  "open",
   "volume",
 ] as const;
 

--- a/src/types/dslSchema.ts
+++ b/src/types/dslSchema.ts
@@ -10,6 +10,7 @@ const identifierValueSchema = z.enum([
   "low",
   "close",
   "volume",
+  "open",
 ]);
 const functionNameSchema = z.enum(["ma", "rsi", "atr"]);
 const binaryOperatorSchema = z.enum([">", "<", ">=", "<=", "==", "!="]);


### PR DESCRIPTION
## Summary
- allow `open` as an identifier in DSL validator and schema
- whitelist `open` column during DSL compilation
- extend property-based generators to emit `open`
- test validation and compilation with `open`
- update JSON schema accordingly

## Testing
- `npx vitest run src/**/*.test.ts src/**/*.spec.ts tests/**/*.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_684fbcb740288332b69e99423a773cbb